### PR TITLE
sbt 0.13.15 -> 0.13.17

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17


### PR DESCRIPTION
no special reason, just good to be on the latest.

(well, 1.1.1 would be the latest, but sbt-dotty doesn't seem to be available for sbt 1 yet)